### PR TITLE
added new method for upload of coverage reports

### DIFF
--- a/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClient.java
+++ b/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClient.java
@@ -272,6 +272,20 @@ public interface MqmRestClient extends BaseMqmRestClient {
 	boolean postLogs(long workspaceId, String selfIdentity, String ciJobId, String ciBuildId, InputStream inputStream, Long contentLength);
 
 	/**
+	 * Sends coverage reports to MQM [POST request].
+	 * InputStream obtained from InputStreamSource is automatically closed after all data are read.
+	 * No exception is expected to be thrown.
+	 * @param selfIdentity identity of the server
+	 * @param ciJobId The job name
+	 * @param ciBuildId The build number.
+	 * @param inputStream The build number.
+	 * @param contentLength The file size .
+	 * @param reportType jacoco or lcov type
+	 * @return The operation status.
+	 */
+	boolean postCoverageReports(String selfIdentity, String ciJobId, String ciBuildId, InputStream inputStream, Long contentLength, String reportType);
+
+	/**
 	 * Retrieves tasks from service working in Abridged Connectivity Mode
 	 *
 	 * @param selfIdentity identity of the server

--- a/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClientImpl.java
+++ b/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClientImpl.java
@@ -916,7 +916,7 @@ public class MqmRestClientImpl extends AbstractMqmRestClient implements MqmRestC
 		}
 		return result;
 	}
-
+	@Override
 	public boolean postCoverageReports(String selfIdentity, String ciJobId, String ciBuildId, InputStream inputStream, Long contentLength, String reportType) {
 		HttpPut request;
 		HttpResponse response = null;

--- a/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClientImpl.java
+++ b/mqm-rest-client/src/main/java/com/hp/mqm/client/MqmRestClientImpl.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -34,6 +35,7 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.protocol.HTTP;
 import org.apache.commons.codec.binary.Base64;
@@ -71,6 +73,7 @@ public class MqmRestClientImpl extends AbstractMqmRestClient implements MqmRestC
 	private static final String URI_GET_ABRIDGED_TASKS = "analytics/ci/servers/{0}/tasks?self-type={1}&self-url={2}&api-version={3}&sdk-version={4}";
 	private static final String URI_PUT_ABRIDGED_RESULT = "analytics/ci/servers/{0}/tasks/{1}/result";
 	private static final String URI_POST_LOGS = "analytics/ci/{0}/{1}/{2}/logs";
+	private static final String URI_POST_COVERAGE_REPORTS = "analytics/ci/coverage?ci-server-identity={0}&ci-job-id={1}&ci-build-id={2}&file-type={3}";
 	private static final String URI_TAXONOMY_NODES = "taxonomy_nodes";
 
 	private static final String HEADER_ACCEPT = "Accept";
@@ -908,6 +911,33 @@ public class MqmRestClientImpl extends AbstractMqmRestClient implements MqmRestC
 			logger.info(IOUtils.toString(response.getEntity().getContent(), "UTF-8"));
 		} catch (IOException e) {
 			throw new RequestErrorException("Cannot post logs to MQM.", e);
+		} finally {
+			HttpClientUtils.closeQuietly(response);
+		}
+		return result;
+	}
+
+	public boolean postCoverageReports(String selfIdentity, String ciJobId, String ciBuildId, InputStream inputStream, Long contentLength, String reportType) {
+		HttpPut request;
+		HttpResponse response = null;
+		boolean result = true;
+
+		try {
+			request = new HttpPut(createSharedSpaceInternalApiUri(URI_POST_COVERAGE_REPORTS, selfIdentity, ciJobId, ciBuildId, reportType));
+			request.setEntity(new GzipCompressingEntity(new InputStreamEntity(inputStream)));
+			response = execute(request);
+			int statusCode = response.getStatusLine().getStatusCode();
+
+			if (statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE || statusCode == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+				result = false;
+				logger.severe("post request failed while sending coverage reports: " + statusCode);
+			} else if (statusCode != HttpStatus.SC_OK) {
+				logger.severe("coverage reports post failed" + statusCode);
+				throw createRequestException("coverage reports post failed", response);
+			}
+			logger.info(IOUtils.toString(response.getEntity().getContent(), "UTF-8"));
+		} catch (IOException e) {
+			throw new RequestErrorException("Cannot post coverage reports to MQM.", e);
 		} finally {
 			HttpClientUtils.closeQuietly(response);
 		}


### PR DESCRIPTION
the change produced in this request is a new method to send coverage reports from jenkins to octain.
this method will be called from jenkins plugin in post build action in case the user configured the sending of coverage reports to octain.